### PR TITLE
Add env example and Unsplash key config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ node_modules
 .DS_Store
 dist
 dist-ssr
-*.local
+*.local.env
+.env

--- a/README.md
+++ b/README.md
@@ -54,3 +54,8 @@ Clonar https://demo.muetab.com/.
 - JavaScript
 
 - Animate.css
+
+### Configuración
+
+1. Copia `env.example` a `.env`.
+2. Coloca tu clave de Unsplash reemplazando `<tu_clave>`.

--- a/env.example
+++ b/env.example
@@ -1,0 +1,1 @@
+VITE_UNSPLASH_KEY=<tu_clave>

--- a/js/main.js
+++ b/js/main.js
@@ -72,7 +72,8 @@ function addWallpaper(data) {
 }
 
 async function getWallpaper() {
-  const url = 'https://api.unsplash.com/photos/random/?client_id=3j0d6XQ7CAPIECX8Srl987CrGxpQLn5g07vL3vgxdco&orientation=landscape&&query=nature';
+  const UNSPLASH_KEY = import.meta.env.VITE_UNSPLASH_KEY;
+  const url = `https://api.unsplash.com/photos/random/?client_id=${UNSPLASH_KEY}&orientation=landscape&&query=nature`;
 
   try {
     const resp = await fetch(url);


### PR DESCRIPTION
## Summary
- document env setup for Unsplash
- add example env file
- ignore .env files
- read Unsplash key from Vite env var

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68483c4ec824832cab1cc71579a87271